### PR TITLE
Toggle hide replys btn4

### DIFF
--- a/js/index/model/renderComments.js
+++ b/js/index/model/renderComments.js
@@ -1,8 +1,11 @@
 // renderComments.js
 import { renderRootComments } from "../view/renderRootComments.js";
 import { renderReplies } from "../view/renderReplies.js";
+import { toggleHiddenReplies } from "../view/toggleHiddenReplies.js";
 
 export function renderComments(comments) {
+  //clear the comments container
+  document.getElementById("comments-container-1").innerHTML = "";
   //check if comments are empty
   if (comments.length === 0) {
     document.getElementById("comments-container-1").innerHTML =
@@ -27,18 +30,15 @@ export function renderComments(comments) {
     return comments.filter((comment) => comment.parentId === commentId).length;
   };
 
-  //render the comments
+  //render the comments,create event listeners for the comment button and render replies
   rootComments.forEach((comment) => {
     renderRootComments(comment, numberOfReplies(comment._id));
 
     //add event listener to the comment button
-    const commentButton = document.getElementById(`commentBtn-${comment._id}`);
-    commentButton.addEventListener("click", () => {
-      const replyContainer = document.getElementById(
-        `reply-container-${comment._id}`
-      );
-      replyContainer.classList.toggle("hidden");
+    requestAnimationFrame(() => {
+      toggleHiddenReplies(comment);
     });
+
     //render replies
     const replies = getReplies(comment._id);
     replies.forEach((reply) => {

--- a/js/index/view/renderRootComments.js
+++ b/js/index/view/renderRootComments.js
@@ -9,7 +9,7 @@ export function renderRootComments(comment, numberOfReplies) {
       <p>${comment.text}</p>
       <div class="buttons">
         <button class="fa-regular fa-heart"></button>
-        <button class="fa-regular fa-comment" id="commentBtn-${comment._id}">${numberOfReplies}</button>
+        <button class="fa-regular fa-comment" id="replyBtn-${comment._id}">${numberOfReplies}</button>
       </div>
       <input
         type="text"

--- a/js/index/view/toggleHiddenReplies.js
+++ b/js/index/view/toggleHiddenReplies.js
@@ -1,0 +1,14 @@
+/**
+ * 1. find the correct element
+ * 2. add event listener to the element
+ * 3. toggle the hidden class
+ */
+export function toggleHiddenReplies(comment) {
+  const commentButton = document.querySelector(`#replyBtn-${comment._id}`);
+  commentButton.addEventListener("click", () => {
+    const replyContainer = document.getElementById(
+      `reply-container-${comment._id}`
+    );
+    replyContainer.classList.toggle("hidden");
+  });
+}


### PR DESCRIPTION
- This pull request will solve issue where btn for toggling class hidden on reply container not firing off properly. 

- i exported code to a new file and added requestAnimationFrame() to solve the problem of adding eventlisteners before HTML is rendered to page. 
- Also i renamed commentBtn to replyBtn since it toggles the replies


